### PR TITLE
🔥 hotfix: GitHub Pages base URL 경로 수정으로 404 에러 해결

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  base: '/portfolio-spaceflight-news/',
+  base: '/spaceflight-news/',
   plugins: [
     TanStackRouterVite({
       target: 'react',


### PR DESCRIPTION
## 🚨 **Hotfix: GitHub Pages 404 에러 해결**

### 📋 **문제 상황**
- GitHub Pages 배포 후 assets 파일들이 404 에러 발생
- CSS, JS 파일 로드 실패로 페이지가 제대로 표시되지 않음
- 잘못된 base URL 경로로 인한 문제

### 🔍 **에러 메시지**
```
GET https://stomx.github.io/portfolio-spaceflight-news/assets/index-B32BjK9Q.js net::ERR_ABORTED 404 (Not Found)
GET https://stomx.github.io/portfolio-spaceflight-news/assets/index-Ddo6qn74.css net::ERR_ABORTED 404 (Not Found)
```

### ⚡ **해결 방법**
- `vite.config.ts`에서 `base` 경로를 `/portfolio-spaceflight-news/`에서 `/spaceflight-news/`로 수정
- GitHub 저장소 이름과 일치하도록 변경

### 🔧 **변경사항**
```diff
- base: '/portfolio-spaceflight-news/',
+ base: '/spaceflight-news/',
```

### ✅ **검증 완료**
- [x] 로컬 빌드 성공
- [x] 올바른 경로로 assets 파일 생성 확인
- [x] 모든 테스트 통과 (30개)
- [x] 린트 검사 통과

### 🎯 **기대 결과**
- GitHub Pages에서 정상적으로 사이트 표시
- 모든 assets 파일 정상 로드
- https://stomx.github.io/spaceflight-news/ 접근 가능

### 🔄 **배포 계획**
1. PR 승인 후 main 브랜치에 머지
2. GitHub Actions 자동 배포 트리거
3. 즉시 GitHub Pages 업데이트

---
**Priority**: 🔥 Critical - 현재 사이트 접근 불가 상태
**Type**: 🐛 Hotfix  
**Impact**: GitHub Pages 배포 사이트 완전 복구