### PR TITLE
hotfix: TanStack Router에 base path 설정 추가

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,7 +3,10 @@ import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { QueryProvider } from './providers/query-provider';
 import { queryClient } from '../shared/api/query-client';
 
-const router = createRouter({ routeTree });
+const router = createRouter({ 
+  routeTree,
+  basepath: '/spaceflight-news'
+});
 
 export function App() {
   return (


### PR DESCRIPTION
## 🐛 문제점
GitHub Pages 배포 시 blog, article 링크 이동 시 `/spaceflight-news/{blogs,articles}`가 되어야 하는데 `/spaceflight-news`가 빠지는 문제가 발생했습니다.

## 🔧 해결 방법
TanStack Router에서 base path를 설정하여 모든 라우터 링크가 올바른 경로로 생성되도록 수정했습니다.

### 변경사항
- `src/app/App.tsx`: `createRouter`에 `basepath: '/spaceflight-news'` 옵션 추가
- 이제 모든 `Link` 컴포넌트와 `navigate` 함수가 자동으로 base path를 포함한 링크를 생성

## ✅ 테스트
- [x] 로컬 빌드 성공
- [x] 프로덕션 미리보기에서 `/spaceflight-news/` 경로 확인
- [x] 네비게이션 링크가 올바른 base path를 포함하여 생성되는지 확인

## 📋 관련 이슈
GitHub Pages 라우팅 문제 해결을 위한 핫픽스입니다.